### PR TITLE
Expurge C99 comments

### DIFF
--- a/Expat/Expat.xs
+++ b/Expat/Expat.xs
@@ -218,8 +218,8 @@ append_error(XML_Parser parser, char * err)
 	      (long)XML_GetCurrentColumnNumber(parser),
 	      (long)XML_GetCurrentByteIndex(parser),
 	      dopos ? ":\n" : "");
-	      // See https://rt.cpan.org/Ticket/Display.html?id=92030
-	      // It explains why type conversion is used.
+	      /* See https://rt.cpan.org/Ticket/Display.html?id=92030
+	         It explains why type conversion is used. */
 	      
     if (dopos)
       {


### PR DESCRIPTION
Expat.xs contains a C99-ism that prevents the module from being built on strict C89 compliant compilers.