### PR TITLE
Support EXPATLIBPATH and EXPATINCPATH from %ENV

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,8 +5,8 @@ use Devel::CheckLib;
 
 use Config;
 
-$expat_libpath = '';
-$expat_incpath = '';
+$expat_libpath = $ENV{EXPATLIBPATH} || '';
+$expat_incpath = $ENV{EXPATINCPATH} || '';
 
 my @replacement_args;
 


### PR DESCRIPTION
make scripting/testing easier by supporting EXPATLIBPATH and EXPATINCPATH
from commanlinearguments *and* environment, so that

$ perl Makefile.PL EXPATLIBPATH=/foo/expat/lib EXPATINCPATH=/foo/expat/include

can also be written as (sh/ksh/bash)

$ export EXPATLIBPATH=/foo/expat/lib
$ export EXPATINCPATH=/foo/expat/include
$ perl Makefile.PL

or (csh/tcsh)

% setenv EXPATLIBPATH /foo/expat/lib
% setenv EXPATINCPATH /foo/expat/include
% perl Makefile.PL