### PR TITLE
Update inc/Devel/CheckLib.pm from 0.99 to 1.14

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,7 +28,9 @@ jobs:
       - name: Set up Perl
         run: |
           choco install strawberryperl
-          echo "C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin" >> $GITHUB_PATH
+          echo "C:\strawberry\c\bin"         >> $GITHUB_PATH
+          echo "C:\strawberry\perl\site\bin" >> $GITHUB_PATH
+          echo "C:\strawberry\perl\bin"      >> $GITHUB_PATH
       - name: perl -V
         run: perl -V
       - name: Makefile.PL

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Perl
         run: |
           choco install strawberryperl
-          echo "##[add-path]C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin"
+          echo "C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin" >> $GITHUB_PATH
       - name: perl -V
         run: perl -V
       - name: Makefile.PL

--- a/inc/Devel/CheckLib.pm
+++ b/inc/Devel/CheckLib.pm
@@ -2,10 +2,10 @@
 
 package Devel::CheckLib;
 
-use 5.00405;    #postfix foreach
+use 5.00405; #postfix foreach
 use strict;
 use vars qw($VERSION @ISA @EXPORT);
-$VERSION = '0.99';
+$VERSION = '1.14';
 use Config qw(%Config);
 use Text::ParseWords 'quotewords';
 
@@ -13,13 +13,13 @@ use File::Spec;
 use File::Temp;
 
 require Exporter;
-@ISA    = qw(Exporter);
+@ISA = qw(Exporter);
 @EXPORT = qw(assert_lib check_lib_or_exit check_lib);
 
 # localising prevents the warningness leaking out of this module
 local $^W = 1;    # use warnings is a 5.6-ism
 
-_findcc();        # bomb out early if there's no compiler
+_findcc(); # bomb out early if there's no compiler
 
 =head1 NAME
 
@@ -54,7 +54,7 @@ and link to the libraries.
 
 It works by trying to compile some code - which defaults to this:
 
-    int main(void) { return 0; }
+    int main(int argc, char *argv[]) { return 0; }
 
 and linking it to the specified libraries.  If something pops out the end
 which looks executable, it gets executed, and if main() returns 0 we know
@@ -109,7 +109,7 @@ representing additional paths to search for libraries.
 
 =item LIBS
 
-a C<ExtUtils::MakeMaker>-style space-seperated list of
+a C<ExtUtils::MakeMaker>-style space-separated list of
 libraries (each preceded by '-l') and directories (preceded by '-L').
 
 This can also be supplied on the command-line.
@@ -137,10 +137,31 @@ representing additional paths to search for headers.
 
 =item INC
 
-a C<ExtUtils::MakeMaker>-style space-seperated list of
+a C<ExtUtils::MakeMaker>-style space-separated list of
 incpaths, each preceded by '-I'.
 
 This can also be supplied on the command-line.
+
+=item ccflags
+
+Extra flags to pass to the compiler.
+
+=item ldflags
+
+Extra flags to pass to the linker.
+
+=item analyze_binary
+
+a callback function that will be invoked in order to perform custom
+analysis of the generated binary. The callback arguments are the
+library name and the path to the binary just compiled.
+
+It is possible to use this callback, for instance, to inspect the
+binary for further dependencies.
+
+=item not_execute
+
+Do not try to execute generated binary. Only check that compilation has not failed.
 
 =back
 
@@ -166,7 +187,7 @@ returning false instead of dieing, or true otherwise.
 
 sub check_lib_or_exit {
     eval 'assert_lib(@_)';
-    if ($@) {
+    if($@) {
         warn $@;
         exit;
     }
@@ -177,214 +198,326 @@ sub check_lib {
     return $@ ? 0 : 1;
 }
 
+# borrowed from Text::ParseWords
+sub _parse_line {
+    my($delimiter, $keep, $line) = @_;
+    my($word, @pieces);
+
+    no warnings 'uninitialized';  # we will be testing undef strings
+
+    while (length($line)) {
+        # This pattern is optimised to be stack conservative on older perls.
+        # Do not refactor without being careful and testing it on very long strings.
+        # See Perl bug #42980 for an example of a stack busting input.
+        $line =~ s/^
+                    (?:
+                        # double quoted string
+                        (")                             # $quote
+                        ((?>[^\\"]*(?:\\.[^\\"]*)*))"   # $quoted
+        | # --OR--
+                        # singe quoted string
+                        (')                             # $quote
+                        ((?>[^\\']*(?:\\.[^\\']*)*))'   # $quoted
+                    |   # --OR--
+                        # unquoted string
+                        (                               # $unquoted
+                            (?:\\.|[^\\"'])*?
+                        )
+                        # followed by
+                        (                               # $delim
+                            \Z(?!\n)                    # EOL
+                        |   # --OR--
+                            (?-x:$delimiter)            # delimiter
+                        |   # --OR--
+                            (?!^)(?=["'])               # a quote
+                        )
+        )//xs or return;    # extended layout
+        my ($quote, $quoted, $unquoted, $delim) = (($1 ? ($1,$2) : ($3,$4)), $5, $6);
+
+        return() unless( defined($quote) || length($unquoted) || length($delim));
+
+        if ($keep) {
+            $quoted = "$quote$quoted$quote";
+        }
+        else {
+            $unquoted =~ s/\\(.)/$1/sg;
+            if (defined $quote) {
+                $quoted =~ s/\\(.)/$1/sg if ($quote eq '"');
+            }
+        }
+        $word .= substr($line, 0, 0); # leave results tainted
+        $word .= defined $quote ? $quoted : $unquoted;
+
+        if (length($delim)) {
+            push(@pieces, $word);
+            push(@pieces, $delim) if ($keep eq 'delimiters');
+            undef $word;
+        }
+        if (!length($line)) {
+            push(@pieces, $word);
+        }
+    }
+    return(@pieces);
+}
+
 sub assert_lib {
     my %args = @_;
-    my ( @libs, @libpaths, @headers, @incpaths );
+    my (@libs, @libpaths, @headers, @incpaths);
 
     # FIXME: these four just SCREAM "refactor" at me
-    @libs = ( ref( $args{lib} ) ? @{ $args{lib} } : $args{lib} )
-      if $args{lib};
-    @libpaths = ( ref( $args{libpath} ) ? @{ $args{libpath} } : $args{libpath} )
-      if $args{libpath};
-    @headers = ( ref( $args{header} ) ? @{ $args{header} } : $args{header} )
-      if $args{header};
-    @incpaths = ( ref( $args{incpath} ) ? @{ $args{incpath} } : $args{incpath} )
-      if $args{incpath};
+    @libs = (ref($args{lib}) ? @{$args{lib}} : $args{lib}) 
+        if $args{lib};
+    @libpaths = (ref($args{libpath}) ? @{$args{libpath}} : $args{libpath}) 
+        if $args{libpath};
+    @headers = (ref($args{header}) ? @{$args{header}} : $args{header}) 
+        if $args{header};
+    @incpaths = (ref($args{incpath}) ? @{$args{incpath}} : $args{incpath}) 
+        if $args{incpath};
+    my $analyze_binary = $args{analyze_binary};
+    my $not_execute = $args{not_execute};
+
+    my @argv = @ARGV;
+    push @argv, _parse_line('\s+', 0, $ENV{PERL_MM_OPT}||'');
 
     # work-a-like for Makefile.PL's LIBS and INC arguments
     # if given as command-line argument, append to %args
-    for my $arg (@ARGV) {
+    for my $arg (@argv) {
         for my $mm_attr_key (qw(LIBS INC)) {
-            if ( my ($mm_attr_value) = $arg =~ /\A $mm_attr_key = (.*)/x ) {
-
-                # it is tempting to put some \s* into the expression, but the
-                # MM command-line parser only accepts LIBS etc. followed by =,
-                # so we should not be any more lenient with whitespace than that
+            if (my ($mm_attr_value) = $arg =~ /\A $mm_attr_key = (.*)/x) {
+            # it is tempting to put some \s* into the expression, but the
+            # MM command-line parser only accepts LIBS etc. followed by =,
+            # so we should not be any more lenient with whitespace than that
                 $args{$mm_attr_key} .= " $mm_attr_value";
             }
         }
     }
 
     # using special form of split to trim whitespace
-    if ( defined( $args{LIBS} ) ) {
-        foreach my $arg ( split( ' ', $args{LIBS} ) ) {
-            die("LIBS argument badly-formed: $arg\n") unless ( $arg =~ /^-[lLR]/ );
-            push @{ $arg =~ /^-l/ ? \@libs : \@libpaths }, substr( $arg, 2 );
+    if(defined($args{LIBS})) {
+        foreach my $arg (split(' ', $args{LIBS})) {
+            die("LIBS argument badly-formed: $arg\n") unless($arg =~ /^-[lLR]/);
+            push @{$arg =~ /^-l/ ? \@libs : \@libpaths}, substr($arg, 2);
         }
     }
-    if ( defined( $args{INC} ) ) {
-        foreach my $arg ( split( ' ', $args{INC} ) ) {
-            die("INC argument badly-formed: $arg\n") unless ( $arg =~ /^-I/ );
-            push @incpaths, substr( $arg, 2 );
+    if(defined($args{INC})) {
+        foreach my $arg (split(' ', $args{INC})) {
+            die("INC argument badly-formed: $arg\n") unless($arg =~ /^-I/);
+            push @incpaths, substr($arg, 2);
         }
     }
 
-    my ( $cc, $ld ) = _findcc();
+    my ($cc, $ld) = _findcc($args{debug}, $args{ccflags}, $args{ldflags});
     my @missing;
     my @wrongresult;
+    my @wronganalysis;
     my @use_headers;
 
     # first figure out which headers we can't find ...
     for my $header (@headers) {
         push @use_headers, $header;
-        my ( $ch, $cfile ) = File::Temp::tempfile( 'assertlibXXXXXXXX', SUFFIX => '.c' );
+        my($ch, $cfile) = File::Temp::tempfile(
+            'assertlibXXXXXXXX', SUFFIX => '.c'
+        );
         my $ofile = $cfile;
         $ofile =~ s/\.c$/$Config{_o}/;
         print $ch qq{#include <$_>\n} for @use_headers;
         print $ch qq{int main(void) { return 0; }\n};
         close($ch);
-        my $exefile = File::Temp::mktemp('assertlibXXXXXXXX') . $Config{_exe};
+        my $exefile = File::Temp::mktemp( 'assertlibXXXXXXXX' ) . $Config{_exe};
         my @sys_cmd;
-
         # FIXME: re-factor - almost identical code later when linking
-        if ( $Config{cc} eq 'cl' ) {    # Microsoft compiler
+        if ( $Config{cc} eq 'cl' ) {                 # Microsoft compiler
             require Win32;
             @sys_cmd = (
                 @$cc,
                 $cfile,
                 "/Fe$exefile",
-                ( map { '/I' . Win32::GetShortPathName($_) } @incpaths ),
-                "/link",
-                @$ld
+                (map { '/I'.Win32::GetShortPathName($_) } @incpaths),
+		"/link",
+		@$ld,
+		split(' ', $Config{libs}),
             );
-        }
-        elsif ( $Config{cc} =~ /bcc32(\.exe)?/ ) {    # Borland
+        } elsif($Config{cc} =~ /bcc32(\.exe)?/) {    # Borland
             @sys_cmd = (
                 @$cc,
                 @$ld,
-                ( map { "-I$_" } @incpaths ),
+                (map { "-I$_" } @incpaths),
                 "-o$exefile",
                 $cfile
             );
-        }
-        else {                                        # Unix-ish: gcc, Sun, AIX (gcc, cc), ...
+        } else { # Unix-ish: gcc, Sun, AIX (gcc, cc), ...
             @sys_cmd = (
                 @$cc,
-                @$ld,
+                (map { "-I$_" } @incpaths),
                 $cfile,
-                ( map { "-I$_" } @incpaths ),
+                @$ld,
                 "-o", "$exefile"
             );
         }
         warn "# @sys_cmd\n" if $args{debug};
         my $rv = $args{debug} ? system(@sys_cmd) : _quiet_system(@sys_cmd);
-        push @missing, $header if $rv != 0 || !-x $exefile;
+        push @missing, $header if $rv != 0 || ! -f $exefile;
         _cleanup_exe($exefile);
-        unlink $ofile if -e $ofile;
         unlink $cfile;
     }
 
     # now do each library in turn with headers
-    my ( $ch, $cfile ) = File::Temp::tempfile( 'assertlibXXXXXXXX', SUFFIX => '.c' );
+    my($ch, $cfile) = File::Temp::tempfile(
+        'assertlibXXXXXXXX', SUFFIX => '.c'
+    );
     my $ofile = $cfile;
     $ofile =~ s/\.c$/$Config{_o}/;
     print $ch qq{#include <$_>\n} foreach (@headers);
-    print $ch "int main(void) { " . ( $args{function} || 'return 0;' ) . " }\n";
+    print $ch "int main(int argc, char *argv[]) { ".($args{function} || 'return 0;')." }\n";
     close($ch);
-    for my $lib (@libs) {
-        my $exefile = File::Temp::mktemp('assertlibXXXXXXXX') . $Config{_exe};
+    for my $lib ( @libs ) {
+        my $exefile = File::Temp::mktemp( 'assertlibXXXXXXXX' ) . $Config{_exe};
         my @sys_cmd;
-        if ( $Config{cc} eq 'cl' ) {    # Microsoft compiler
+        if ( $Config{cc} eq 'cl' ) {                 # Microsoft compiler
             require Win32;
-            my @libpath = map { q{/libpath:} . Win32::GetShortPathName($_) } @libpaths;
-
+            my @libpath = map { 
+                q{/libpath:} . Win32::GetShortPathName($_)
+            } @libpaths; 
             # this is horribly sensitive to the order of arguments
             @sys_cmd = (
                 @$cc,
                 $cfile,
                 "${lib}.lib",
-                "/Fe$exefile",
-                ( map { '/I' . Win32::GetShortPathName($_) } @incpaths ),
+                "/Fe$exefile", 
+                (map { '/I'.Win32::GetShortPathName($_) } @incpaths),
                 "/link",
                 @$ld,
-                ( map { '/libpath:' . Win32::GetShortPathName($_) } @libpaths ),
+                split(' ', $Config{libs}),
+                (map {'/libpath:'.Win32::GetShortPathName($_)} @libpaths),
             );
-        }
-        elsif ( $Config{cc} eq 'CC/DECC' ) {    # VMS
-        }
-        elsif ( $Config{cc} =~ /bcc32(\.exe)?/ ) {    # Borland
+        } elsif($Config{cc} eq 'CC/DECC') {          # VMS
+        } elsif($Config{cc} =~ /bcc32(\.exe)?/) {    # Borland
             @sys_cmd = (
                 @$cc,
                 @$ld,
                 "-o$exefile",
-                ( map { "-I$_" } @incpaths ),
-                ( map { "-L$_" } @libpaths ),
+                (map { "-I$_" } @incpaths),
+                (map { "-L$_" } @libpaths),
                 "-l$lib",
-                $cfile
-            );
-        }
-        else {                                        # Unix-ish
-                                                      # gcc, Sun, AIX (gcc, cc)
+                $cfile);
+        } else {                                     # Unix-ish
+                                                     # gcc, Sun, AIX (gcc, cc)
             @sys_cmd = (
                 @$cc,
-                @$ld,
+                (map { "-I$_" } @incpaths),
                 $cfile,
-                "-o", "$exefile",
-                ( map { "-I$_" } @incpaths ),
-                ( map { "-L$_" } @libpaths ),
+                (map { "-L$_" } @libpaths),
                 "-l$lib",
+                @$ld,
+                "-o", "$exefile",
             );
         }
         warn "# @sys_cmd\n" if $args{debug};
+        local $ENV{LD_RUN_PATH} = join(":", grep $_, @libpaths, $ENV{LD_RUN_PATH}) unless $^O eq 'MSWin32';
+        local $ENV{PATH} = join(";", @libpaths).";".$ENV{PATH} if $^O eq 'MSWin32';
         my $rv = $args{debug} ? system(@sys_cmd) : _quiet_system(@sys_cmd);
-        push @missing, $lib if $rv != 0 || !-x $exefile;
-        my $absexefile = File::Spec->rel2abs($exefile);
-        $absexefile = '"' . $absexefile . '"' if $absexefile =~ m/\s/;
-        push @wrongresult, $lib if $rv == 0 && -x $exefile && system($absexefile) != 0;
-        unlink $ofile if -e $ofile;
+        if ($rv != 0 || ! -f $exefile) {
+            push @missing, $lib;
+        }
+        else {
+            chmod 0755, $exefile;
+            my $absexefile = File::Spec->rel2abs($exefile);
+            $absexefile = '"'.$absexefile.'"' if $absexefile =~ m/\s/;
+            if (!$not_execute && system($absexefile) != 0) {
+                push @wrongresult, $lib;
+            }
+            else {
+                if ($analyze_binary) {
+                    push @wronganalysis, $lib if !$analyze_binary->($lib, $exefile)
+                }
+            }
+        }
         _cleanup_exe($exefile);
-    }
+    } 
     unlink $cfile;
 
     my $miss_string = join( q{, }, map { qq{'$_'} } @missing );
     die("Can't link/include C library $miss_string, aborting.\n") if @missing;
-    my $wrong_string = join( q{, }, map { qq{'$_'} } @wrongresult );
+    my $wrong_string = join( q{, }, map { qq{'$_'} } @wrongresult);
     die("wrong result: $wrong_string\n") if @wrongresult;
+    my $analysis_string = join(q{, }, map { qq{'$_'} } @wronganalysis );
+    die("wrong analysis: $analysis_string") if @wronganalysis;
 }
 
 sub _cleanup_exe {
     my ($exefile) = @_;
     my $ofile = $exefile;
     $ofile =~ s/$Config{_exe}$/$Config{_o}/;
-    unlink $exefile             if -f $exefile;
-    unlink $ofile               if -f $ofile;
-    unlink "$exefile\.manifest" if -f "$exefile\.manifest";
+    # List of files to remove
+    my @rmfiles;
+    push @rmfiles, $exefile, $ofile, "$exefile\.manifest";
     if ( $Config{cc} eq 'cl' ) {
-
         # MSVC also creates foo.ilk and foo.pdb
         my $ilkfile = $exefile;
         $ilkfile =~ s/$Config{_exe}$/.ilk/;
         my $pdbfile = $exefile;
         $pdbfile =~ s/$Config{_exe}$/.pdb/;
-        unlink $ilkfile if -f $ilkfile;
-        unlink $pdbfile if -f $pdbfile;
+	push @rmfiles, $ilkfile, $pdbfile;
     }
-    return;
+    foreach (@rmfiles) {
+	if ( -f $_ ) {
+	    unlink $_ or warn "Could not remove $_: $!";
+	}
+    }
+    return
 }
-
+    
 # return ($cc, $ld)
 # where $cc is an array ref of compiler name, compiler flags
 # where $ld is an array ref of linker flags
 sub _findcc {
-
+    my ($debug, $user_ccflags, $user_ldflags) = @_;
     # Need to use $keep=1 to work with MSWin32 backslashes and quotes
-    my $Config_ccflags = $Config{ccflags};    # use copy so ASPerl will compile
+    my $Config_ccflags =  $Config{ccflags};  # use copy so ASPerl will compile
     my @Config_ldflags = ();
-    for my $config_val ( @Config{qw(ldflags perllibs)} ) {
+    for my $config_val ( @Config{qw(ldflags)} ){
         push @Config_ldflags, $config_val if ( $config_val =~ /\S/ );
     }
-    my @ccflags = grep { length } quotewords( '\s+', 1, $Config_ccflags || '' );
-    my @ldflags = grep { length } quotewords( '\s+', 1, @Config_ldflags );
-    my @paths = split( /$Config{path_sep}/, $ENV{PATH} );
-    my @cc = split( /\s+/, $Config{cc} );
-    return ( [ @cc, @ccflags ], \@ldflags ) if -x $cc[0];
-    foreach my $path (@paths) {
-        my $compiler = File::Spec->catfile( $path, $cc[0] ) . $Config{_exe};
-        return ( [ $compiler, @cc[ 1 .. $#cc ], @ccflags ], \@ldflags )
-          if -x $compiler;
+    my @ccflags = grep { length } quotewords('\s+', 1, $Config_ccflags||'', $user_ccflags||'');
+    my @ldflags = grep { length && $_ !~ m/^-Wl/ } quotewords('\s+', 1, @Config_ldflags, $user_ldflags||'');
+    my @paths = split(/$Config{path_sep}/, $ENV{PATH});
+    my @cc = split(/\s+/, $Config{cc});
+    if (check_compiler ($cc[0], $debug)) {
+	return ( [ @cc, @ccflags ], \@ldflags );
     }
-    die("Couldn't find your C compiler\n");
+    # Find the extension for executables.
+    my $exe = $Config{_exe};
+    if ($^O eq 'cygwin') {
+	$exe = '';
+    }
+    foreach my $path (@paths) {
+	# Look for "$path/$cc[0].exe"
+        my $compiler = File::Spec->catfile($path, $cc[0]) . $exe;
+	if (check_compiler ($compiler, $debug)) {
+	    return ([ $compiler, @cc[1 .. $#cc], @ccflags ], \@ldflags)
+	}
+        next if ! $exe;
+	# Look for "$path/$cc[0]" without the .exe, if necessary.
+        $compiler = File::Spec->catfile($path, $cc[0]);
+	if (check_compiler ($compiler, $debug)) {
+	    return ([ $compiler, @cc[1 .. $#cc], @ccflags ], \@ldflags)
+	}
+    }
+    die("Couldn't find your C compiler.\n");
 }
+
+sub check_compiler
+{
+    my ($compiler, $debug) = @_;
+    if (-f $compiler && -x $compiler) {
+	if ($debug) {
+	    warn("# Compiler seems to be $compiler\n");
+	}
+	return 1;
+    }
+    return '';
+}
+
 
 # code substantially borrowed from IPC::Run3
 sub _quiet_system {
@@ -395,24 +528,24 @@ sub _quiet_system {
     local *STDERR_SAVE;
     open STDOUT_SAVE, ">&STDOUT" or die "CheckLib: $! saving STDOUT";
     open STDERR_SAVE, ">&STDERR" or die "CheckLib: $! saving STDERR";
-
+    
     # redirect to nowhere
     local *DEV_NULL;
-    open DEV_NULL, ">" . File::Spec->devnull
-      or die "CheckLib: $! opening handle to null device";
+    open DEV_NULL, ">" . File::Spec->devnull 
+        or die "CheckLib: $! opening handle to null device";
     open STDOUT, ">&" . fileno DEV_NULL
-      or die "CheckLib: $! redirecting STDOUT to null handle";
+        or die "CheckLib: $! redirecting STDOUT to null handle";
     open STDERR, ">&" . fileno DEV_NULL
-      or die "CheckLib: $! redirecting STDERR to null handle";
+        or die "CheckLib: $! redirecting STDERR to null handle";
 
     # run system command
     my $rv = system(@cmd);
 
     # restore handles
     open STDOUT, ">&" . fileno STDOUT_SAVE
-      or die "CheckLib: $! restoring STDOUT handle";
+        or die "CheckLib: $! restoring STDOUT handle";
     open STDERR, ">&" . fileno STDERR_SAVE
-      or die "CheckLib: $! restoring STDERR handle";
+        or die "CheckLib: $! restoring STDERR handle";
 
     return $rv;
 }
@@ -422,7 +555,7 @@ sub _quiet_system {
 You must have a C compiler installed.  We check for C<$Config{cc}>,
 both literally as it is in Config.pm and also in the $PATH.
 
-It has been tested with varying degrees on rigourousness on:
+It has been tested with varying degrees of rigorousness on:
 
 =over
 


### PR DESCRIPTION
This is a pull request for #86. For reference, "hide from PAUSE" hack, which was once done by (deprecated) use-devel-checklib script, is unnecessary for inc/ directory.