### PR TITLE
Check for 'libexpat' rather than 'expat' on Windows

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -30,7 +30,7 @@ foreach (@ARGV) {
 
 unless (
     check_lib(    # fill in what you prompted the user for here
-        lib     => [qw(expat)],
+        lib     => [$^O eq 'MSWin32' ? qw(libexpat) : qw(expat)],
         header  => ['expat.h'],
         incpath => $expat_incpath,
         ( $expat_libpath ? ( libpath => $expat_libpath ) : () ),


### PR DESCRIPTION
With Expat built (in its default configuration) and installed into C:\Programs\expat the following command should work but doesn't unless we check for 'libexpat' rather than 'expat':
perl Makefile.PL EXPATLIBPATH=C:\Programs\expat\lib EXPATINCPATH=C:\Programs\expat\include

(The (DLL import) libray is C:\Programs\expat\lib\libexpat.lib. The DLL itself is C:\Programs\expat\bin\libexpat.dll.)