### PR TITLE
workflows(macos): fix runner image ref

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,7 +16,7 @@ jobs:
       AUTOMATED_TESTING: 1
       RELEASE_TESTING: 1
 
-    runs-on: macOS-latest
+    runs-on: macos-13
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
it should be `macos-latest` rather than `macOS-latest`. (`https://github.com/actions/runner-images/`)

also bump to `macos-13` as it is the newest image rn, `macos-latest` still points to `macos-12`

cc @toddr 